### PR TITLE
Handle malformed localStorage

### DIFF
--- a/src/app/(app)/products/[productId]/page.tsx
+++ b/src/app/(app)/products/[productId]/page.tsx
@@ -43,7 +43,20 @@ export default function ProductDetailPage() {
     if (product.id.startsWith("USER_PROD")) {
       try {
         const storedProductsString = localStorage.getItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
-        let userProducts: StoredUserProduct[] = storedProductsString ? JSON.parse(storedProductsString) : [];
+        let userProducts: StoredUserProduct[] = [];
+        if (storedProductsString) {
+          try {
+            userProducts = JSON.parse(storedProductsString);
+          } catch (err) {
+            console.error('Failed to parse user products from localStorage', err);
+            localStorage.removeItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
+            toast({
+              title: 'Local Storage Reset',
+              description: 'Stored product data was corrupted and has been cleared.',
+              variant: 'destructive'
+            });
+          }
+        }
         const productIndex = userProducts.findIndex(p => p.id === product.id);
         if (productIndex > -1) {
           userProducts[productIndex] = {
@@ -114,7 +127,20 @@ export default function ProductDetailPage() {
 
       if (product.id.startsWith("USER_PROD")) {
         const storedProductsString = localStorage.getItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
-        let userProducts: StoredUserProduct[] = storedProductsString ? JSON.parse(storedProductsString) : [];
+        let userProducts: StoredUserProduct[] = [];
+        if (storedProductsString) {
+          try {
+            userProducts = JSON.parse(storedProductsString);
+          } catch (err) {
+            console.error('Failed to parse user products from localStorage', err);
+            localStorage.removeItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
+            toast({
+              title: 'Local Storage Reset',
+              description: 'Stored product data was corrupted and has been cleared.',
+              variant: 'destructive'
+            });
+          }
+        }
         const productIndex = userProducts.findIndex(p => p.id === product.id);
         if (productIndex > -1) {
           if (!userProducts[productIndex].complianceSummary) { 

--- a/src/app/(app)/products/new/page.tsx
+++ b/src/app/(app)/products/new/page.tsx
@@ -158,7 +158,20 @@ export default function AddNewProductPage() {
   useEffect(() => {
     if (isEditMode && editProductId) {
       const storedProductsString = localStorage.getItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
-      const userProducts: StoredUserProduct[] = storedProductsString ? JSON.parse(storedProductsString) : [];
+      let userProducts: StoredUserProduct[] = [];
+      if (storedProductsString) {
+        try {
+          userProducts = JSON.parse(storedProductsString);
+        } catch (err) {
+          console.error('Failed to parse user products from localStorage', err);
+          localStorage.removeItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
+          toast({
+            title: 'Local Storage Reset',
+            description: 'Stored product data was corrupted and has been cleared.',
+            variant: 'destructive'
+          });
+        }
+      }
       const productToEdit = userProducts.find(p => p.id === editProductId);
       if (productToEdit) {
         const editData: InitialProductFormData = {
@@ -343,7 +356,20 @@ export default function AddNewProductPage() {
 
     try {
       const storedProductsString = localStorage.getItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
-      let userProducts: StoredUserProduct[] = storedProductsString ? JSON.parse(storedProductsString) : [];
+      let userProducts: StoredUserProduct[] = [];
+      if (storedProductsString) {
+        try {
+          userProducts = JSON.parse(storedProductsString);
+        } catch (err) {
+          console.error('Failed to parse user products from localStorage', err);
+          localStorage.removeItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
+          toast({
+            title: 'Local Storage Reset',
+            description: 'Stored product data was corrupted and has been cleared.',
+            variant: 'destructive'
+          });
+        }
+      }
 
       const productCoreData: StoredUserProduct = {
         id: isEditMode && editProductId ? editProductId : `USER_PROD_${Date.now().toString().slice(-6)}`,

--- a/src/app/(app)/products/page.tsx
+++ b/src/app/(app)/products/page.tsx
@@ -118,7 +118,20 @@ export default function ProductsPage() {
 
   useEffect(() => {
     const storedProductsString = localStorage.getItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
-    const userAddedStoredProducts: StoredUserProduct[] = storedProductsString ? JSON.parse(storedProductsString) : [];
+    let userAddedStoredProducts: StoredUserProduct[] = [];
+    if (storedProductsString) {
+      try {
+        userAddedStoredProducts = JSON.parse(storedProductsString);
+      } catch (err) {
+        console.error('Failed to parse user products from localStorage', err);
+        localStorage.removeItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
+        toast({
+          title: 'Local Storage Reset',
+          description: 'Stored product data was corrupted and has been cleared.',
+          variant: 'destructive'
+        });
+      }
+    }
 
     const userAddedDisplayable: ProductWithCompleteness[] = userAddedStoredProducts.map(p => ({
       ...p,
@@ -227,7 +240,20 @@ export default function ProductsPage() {
 
     if (productToDelete.id.startsWith("USER_PROD")) {
       const storedProductsString = localStorage.getItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
-      let userAddedProducts: StoredUserProduct[] = storedProductsString ? JSON.parse(storedProductsString) : [];
+      let userAddedProducts: StoredUserProduct[] = [];
+      if (storedProductsString) {
+        try {
+          userAddedProducts = JSON.parse(storedProductsString);
+        } catch (err) {
+          console.error('Failed to parse user products from localStorage', err);
+          localStorage.removeItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
+          toast({
+            title: 'Local Storage Reset',
+            description: 'Stored product data was corrupted and has been cleared.',
+            variant: 'destructive'
+          });
+        }
+      }
       userAddedProducts = userAddedProducts.filter(p => p.id !== productToDelete.id);
       localStorage.setItem(USER_PRODUCTS_LOCAL_STORAGE_KEY, JSON.stringify(userAddedProducts));
     }

--- a/src/app/(app)/suppliers/page.tsx
+++ b/src/app/(app)/suppliers/page.tsx
@@ -27,7 +27,20 @@ export default function SuppliersPage() {
 
   useEffect(() => {
     const storedSuppliersString = localStorage.getItem(USER_SUPPLIERS_LOCAL_STORAGE_KEY);
-    const userAddedSuppliers: Supplier[] = storedSuppliersString ? JSON.parse(storedSuppliersString) : [];
+    let userAddedSuppliers: Supplier[] = [];
+    if (storedSuppliersString) {
+      try {
+        userAddedSuppliers = JSON.parse(storedSuppliersString);
+      } catch (err) {
+        console.error('Failed to parse suppliers from localStorage', err);
+        localStorage.removeItem(USER_SUPPLIERS_LOCAL_STORAGE_KEY);
+        toast({
+          title: 'Local Storage Reset',
+          description: 'Stored supplier data was corrupted and has been cleared.',
+          variant: 'destructive'
+        });
+      }
+    }
     
     const combinedSuppliers = [
       ...MOCK_SUPPLIERS.filter(mockSup => !userAddedSuppliers.find(userSup => userSup.id === mockSup.id)),

--- a/src/components/products/detail/SupplyChainTab.tsx
+++ b/src/components/products/detail/SupplyChainTab.tsx
@@ -67,7 +67,20 @@ export default function SupplyChainTab({ product, onSupplyChainLinksChange }: Su
   useEffect(() => {
     setIsClient(true);
     const storedSuppliersString = localStorage.getItem(USER_SUPPLIERS_LOCAL_STORAGE_KEY);
-    const userAddedSuppliers: Supplier[] = storedSuppliersString ? JSON.parse(storedSuppliersString) : [];
+    let userAddedSuppliers: Supplier[] = [];
+    if (storedSuppliersString) {
+      try {
+        userAddedSuppliers = JSON.parse(storedSuppliersString);
+      } catch (err) {
+        console.error('Failed to parse suppliers from localStorage', err);
+        localStorage.removeItem(USER_SUPPLIERS_LOCAL_STORAGE_KEY);
+        toast({
+          title: 'Local Storage Reset',
+          description: 'Stored supplier data was corrupted and has been cleared.',
+          variant: 'destructive'
+        });
+      }
+    }
     const combinedSuppliers = [
       ...MOCK_SUPPLIERS.filter(mockSup => !userAddedSuppliers.find(userSup => userSup.id === mockSup.id)),
       ...userAddedSuppliers

--- a/src/hooks/useDPPLiveData.ts
+++ b/src/hooks/useDPPLiveData.ts
@@ -30,7 +30,20 @@ export function useDPPLiveData() {
 
   useEffect(() => {
     const storedProductsString = localStorage.getItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
-    const userAddedProducts: DigitalProductPassport[] = storedProductsString ? JSON.parse(storedProductsString) : [];
+    let userAddedProducts: DigitalProductPassport[] = [];
+    if (storedProductsString) {
+      try {
+        userAddedProducts = JSON.parse(storedProductsString);
+      } catch (err) {
+        console.error('Failed to parse user products from localStorage', err);
+        localStorage.removeItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
+        toast({
+          title: 'Local Storage Reset',
+          description: 'Stored product data was corrupted and has been cleared.',
+          variant: 'destructive'
+        });
+      }
+    }
     
     const combinedProducts = [
       ...MOCK_DPPS.filter(mockDpp => !userAddedProducts.find(userDpp => userDpp.id === mockDpp.id)),
@@ -120,7 +133,20 @@ export function useDPPLiveData() {
     const productIsUserAdded = productToDeleteId.startsWith("USER_PROD");
     if (productIsUserAdded) {
       const storedProductsString = localStorage.getItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
-      let userProducts: DigitalProductPassport[] = storedProductsString ? JSON.parse(storedProductsString) : [];
+      let userProducts: DigitalProductPassport[] = [];
+      if (storedProductsString) {
+        try {
+          userProducts = JSON.parse(storedProductsString);
+        } catch (err) {
+          console.error('Failed to parse user products from localStorage', err);
+          localStorage.removeItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
+          toast({
+            title: 'Local Storage Reset',
+            description: 'Stored product data was corrupted and has been cleared.',
+            variant: 'destructive'
+          });
+        }
+      }
       userProducts = userProducts.filter(p => p.id !== productToDeleteId);
       localStorage.setItem(USER_PRODUCTS_LOCAL_STORAGE_KEY, JSON.stringify(userProducts));
     }

--- a/src/utils/productDetailUtils.ts
+++ b/src/utils/productDetailUtils.ts
@@ -171,7 +171,13 @@ export async function fetchProductDetails(productId: string): Promise<SimpleProd
 
   const storedProductsString = typeof window !== 'undefined' ? localStorage.getItem(USER_PRODUCTS_LOCAL_STORAGE_KEY) : null;
   if (storedProductsString) {
-    const userProducts: StoredUserProduct[] = JSON.parse(storedProductsString);
+    let userProducts: StoredUserProduct[] = [];
+    try {
+      userProducts = JSON.parse(storedProductsString);
+    } catch (err) {
+      console.error('Failed to parse user products from localStorage', err);
+      localStorage.removeItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
+    }
     const userProductData = userProducts.find(p => p.id === productId);
     if (userProductData) {
       let parsedCustomAttributes: CustomAttribute[] = [];

--- a/workspace/src/app/(app)/my-products/page.tsx
+++ b/workspace/src/app/(app)/my-products/page.tsx
@@ -24,7 +24,20 @@ export default function MyTrackedProductsPage() {
   const loadTrackedProducts = useCallback(() => {
     setIsLoading(true);
     const storedIdsString = localStorage.getItem(TRACKED_PRODUCTS_STORAGE_KEY);
-    const trackedIds: string[] = storedIdsString ? JSON.parse(storedIdsString) : [];
+    let trackedIds: string[] = [];
+    if (storedIdsString) {
+      try {
+        trackedIds = JSON.parse(storedIdsString);
+      } catch (err) {
+        console.error('Failed to parse tracked product IDs from localStorage', err);
+        localStorage.removeItem(TRACKED_PRODUCTS_STORAGE_KEY);
+        toast({
+          title: 'Local Storage Reset',
+          description: 'Tracked product data was corrupted and has been cleared.',
+          variant: 'destructive'
+        });
+      }
+    }
     
     const productsToDisplay: TrackedProductDisplayInfo[] = trackedIds.map(id => {
       const publicInfo = MOCK_PUBLIC_PASSPORTS[id] || MOCK_PUBLIC_PASSPORTS[`PROD${id.replace('DPP','')}`] ; // Attempt mapping if needed
@@ -57,7 +70,20 @@ export default function MyTrackedProductsPage() {
 
   const handleUntrackProduct = (productId: string) => {
     const storedIdsString = localStorage.getItem(TRACKED_PRODUCTS_STORAGE_KEY);
-    let trackedIds: string[] = storedIdsString ? JSON.parse(storedIdsString) : [];
+    let trackedIds: string[] = [];
+    if (storedIdsString) {
+      try {
+        trackedIds = JSON.parse(storedIdsString);
+      } catch (err) {
+        console.error('Failed to parse tracked product IDs from localStorage', err);
+        localStorage.removeItem(TRACKED_PRODUCTS_STORAGE_KEY);
+        toast({
+          title: 'Local Storage Reset',
+          description: 'Tracked product data was corrupted and has been cleared.',
+          variant: 'destructive'
+        });
+      }
+    }
     trackedIds = trackedIds.filter(id => id !== productId);
     localStorage.setItem(TRACKED_PRODUCTS_STORAGE_KEY, JSON.stringify(trackedIds));
     loadTrackedProducts(); // Reload the list

--- a/workspace/src/app/(app)/products/[productId]/page.tsx
+++ b/workspace/src/app/(app)/products/[productId]/page.tsx
@@ -43,7 +43,20 @@ export default function ProductDetailPage() {
     if (product.id.startsWith("USER_PROD")) {
       try {
         const storedProductsString = localStorage.getItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
-        let userProducts: StoredUserProduct[] = storedProductsString ? JSON.parse(storedProductsString) : [];
+        let userProducts: StoredUserProduct[] = [];
+        if (storedProductsString) {
+          try {
+            userProducts = JSON.parse(storedProductsString);
+          } catch (err) {
+            console.error('Failed to parse user products from localStorage', err);
+            localStorage.removeItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
+            toast({
+              title: 'Local Storage Reset',
+              description: 'Stored product data was corrupted and has been cleared.',
+              variant: 'destructive'
+            });
+          }
+        }
         const productIndex = userProducts.findIndex(p => p.id === product.id);
         if (productIndex > -1) {
           userProducts[productIndex] = {
@@ -115,7 +128,20 @@ export default function ProductDetailPage() {
 
       if (product.id.startsWith("USER_PROD")) {
         const storedProductsString = localStorage.getItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
-        let userProducts: StoredUserProduct[] = storedProductsString ? JSON.parse(storedProductsString) : [];
+        let userProducts: StoredUserProduct[] = [];
+        if (storedProductsString) {
+          try {
+            userProducts = JSON.parse(storedProductsString);
+          } catch (err) {
+            console.error('Failed to parse user products from localStorage', err);
+            localStorage.removeItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
+            toast({
+              title: 'Local Storage Reset',
+              description: 'Stored product data was corrupted and has been cleared.',
+              variant: 'destructive'
+            });
+          }
+        }
         const productIndex = userProducts.findIndex(p => p.id === product.id);
         if (productIndex > -1) {
           if (!userProducts[productIndex].complianceSummary) { 

--- a/workspace/src/app/(app)/products/new/page.tsx
+++ b/workspace/src/app/(app)/products/new/page.tsx
@@ -226,7 +226,20 @@ export default function AddNewProductPage() {
   useEffect(() => {
     if (isEditMode && editProductId) {
       const storedProductsString = localStorage.getItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
-      const userProducts: StoredUserProduct[] = storedProductsString ? JSON.parse(storedProductsString) : [];
+      let userProducts: StoredUserProduct[] = [];
+      if (storedProductsString) {
+        try {
+          userProducts = JSON.parse(storedProductsString);
+        } catch (err) {
+          console.error('Failed to parse user products from localStorage', err);
+          localStorage.removeItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
+          toast({
+            title: 'Local Storage Reset',
+            description: 'Stored product data was corrupted and has been cleared.',
+            variant: 'destructive'
+          });
+        }
+      }
       const productToEdit = userProducts.find(p => p.id === editProductId);
       if (productToEdit) {
         const editData: InitialProductFormData = {
@@ -459,7 +472,20 @@ export default function AddNewProductPage() {
 
     try {
       const storedProductsString = localStorage.getItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
-      let userProducts: StoredUserProduct[] = storedProductsString ? JSON.parse(storedProductsString) : [];
+      let userProducts: StoredUserProduct[] = [];
+      if (storedProductsString) {
+        try {
+          userProducts = JSON.parse(storedProductsString);
+        } catch (err) {
+          console.error('Failed to parse user products from localStorage', err);
+          localStorage.removeItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
+          toast({
+            title: 'Local Storage Reset',
+            description: 'Stored product data was corrupted and has been cleared.',
+            variant: 'destructive'
+          });
+        }
+      }
 
       const productCoreData: StoredUserProduct = {
         id: isEditMode && editProductId ? editProductId : `USER_PROD_${Date.now().toString().slice(-6)}`,

--- a/workspace/src/app/(app)/products/page.tsx
+++ b/workspace/src/app/(app)/products/page.tsx
@@ -111,7 +111,20 @@ export default function ProductsPage() {
 
   useEffect(() => {
     const storedProductsString = localStorage.getItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
-    const userAddedStoredProducts: StoredUserProduct[] = storedProductsString ? JSON.parse(storedProductsString) : [];
+    let userAddedStoredProducts: StoredUserProduct[] = [];
+    if (storedProductsString) {
+      try {
+        userAddedStoredProducts = JSON.parse(storedProductsString);
+      } catch (err) {
+        console.error('Failed to parse user products from localStorage', err);
+        localStorage.removeItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
+        toast({
+          title: 'Local Storage Reset',
+          description: 'Stored product data was corrupted and has been cleared.',
+          variant: 'destructive'
+        });
+      }
+    }
 
     const userAddedDisplayable: ProductWithCompleteness[] = userAddedStoredProducts.map(p => ({
       ...p,
@@ -224,7 +237,20 @@ export default function ProductsPage() {
 
     if (productToDelete.id.startsWith("USER_PROD")) {
       const storedProductsString = localStorage.getItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
-      let userAddedProducts: StoredUserProduct[] = storedProductsString ? JSON.parse(storedProductsString) : [];
+      let userAddedProducts: StoredUserProduct[] = [];
+      if (storedProductsString) {
+        try {
+          userAddedProducts = JSON.parse(storedProductsString);
+        } catch (err) {
+          console.error('Failed to parse user products from localStorage', err);
+          localStorage.removeItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
+          toast({
+            title: 'Local Storage Reset',
+            description: 'Stored product data was corrupted and has been cleared.',
+            variant: 'destructive'
+          });
+        }
+      }
       userAddedProducts = userAddedProducts.filter(p => p.id !== productToDelete.id);
       localStorage.setItem(USER_PRODUCTS_LOCAL_STORAGE_KEY, JSON.stringify(userAddedProducts));
     }

--- a/workspace/src/app/(app)/suppliers/page.tsx
+++ b/workspace/src/app/(app)/suppliers/page.tsx
@@ -27,7 +27,20 @@ export default function SuppliersPage() {
 
   useEffect(() => {
     const storedSuppliersString = localStorage.getItem(USER_SUPPLIERS_LOCAL_STORAGE_KEY);
-    const userAddedSuppliers: Supplier[] = storedSuppliersString ? JSON.parse(storedSuppliersString) : [];
+    let userAddedSuppliers: Supplier[] = [];
+    if (storedSuppliersString) {
+      try {
+        userAddedSuppliers = JSON.parse(storedSuppliersString);
+      } catch (err) {
+        console.error('Failed to parse suppliers from localStorage', err);
+        localStorage.removeItem(USER_SUPPLIERS_LOCAL_STORAGE_KEY);
+        toast({
+          title: 'Local Storage Reset',
+          description: 'Stored supplier data was corrupted and has been cleared.',
+          variant: 'destructive'
+        });
+      }
+    }
     
     const combinedSuppliers = [
       ...MOCK_SUPPLIERS.filter(mockSup => !userAddedSuppliers.find(userSup => userSup.id === mockSup.id)),

--- a/workspace/src/app/passport/[passportId]/page.tsx
+++ b/workspace/src/app/passport/[passportId]/page.tsx
@@ -43,7 +43,20 @@ export default function PublicPassportPage() {
 
   const updateTrackedStatus = useCallback(() => {
     const storedIdsString = localStorage.getItem(TRACKED_PRODUCTS_STORAGE_KEY);
-    const trackedIds: string[] = storedIdsString ? JSON.parse(storedIdsString) : [];
+    let trackedIds: string[] = [];
+    if (storedIdsString) {
+      try {
+        trackedIds = JSON.parse(storedIdsString);
+      } catch (err) {
+        console.error('Failed to parse tracked product IDs from localStorage', err);
+        localStorage.removeItem(TRACKED_PRODUCTS_STORAGE_KEY);
+        toast({
+          title: 'Local Storage Reset',
+          description: 'Tracked product data was corrupted and has been cleared.',
+          variant: 'destructive'
+        });
+      }
+    }
     setIsTracked(trackedIds.includes(passportId));
   }, [passportId]);
 
@@ -67,7 +80,20 @@ export default function PublicPassportPage() {
 
   const handleToggleTrackProduct = () => {
     const storedIdsString = localStorage.getItem(TRACKED_PRODUCTS_STORAGE_KEY);
-    let trackedIds: string[] = storedIdsString ? JSON.parse(storedIdsString) : [];
+    let trackedIds: string[] = [];
+    if (storedIdsString) {
+      try {
+        trackedIds = JSON.parse(storedIdsString);
+      } catch (err) {
+        console.error('Failed to parse tracked product IDs from localStorage', err);
+        localStorage.removeItem(TRACKED_PRODUCTS_STORAGE_KEY);
+        toast({
+          title: 'Local Storage Reset',
+          description: 'Tracked product data was corrupted and has been cleared.',
+          variant: 'destructive'
+        });
+      }
+    }
     const productIndex = trackedIds.indexOf(passportId);
 
     if (productIndex > -1) {

--- a/workspace/src/components/products/detail/SupplyChainTab.tsx
+++ b/workspace/src/components/products/detail/SupplyChainTab.tsx
@@ -67,7 +67,20 @@ export default function SupplyChainTab({ product, onSupplyChainLinksChange }: Su
   useEffect(() => {
     setIsClient(true);
     const storedSuppliersString = localStorage.getItem(USER_SUPPLIERS_LOCAL_STORAGE_KEY);
-    const userAddedSuppliers: Supplier[] = storedSuppliersString ? JSON.parse(storedSuppliersString) : [];
+    let userAddedSuppliers: Supplier[] = [];
+    if (storedSuppliersString) {
+      try {
+        userAddedSuppliers = JSON.parse(storedSuppliersString);
+      } catch (err) {
+        console.error('Failed to parse suppliers from localStorage', err);
+        localStorage.removeItem(USER_SUPPLIERS_LOCAL_STORAGE_KEY);
+        toast({
+          title: 'Local Storage Reset',
+          description: 'Stored supplier data was corrupted and has been cleared.',
+          variant: 'destructive'
+        });
+      }
+    }
     const combinedSuppliers = [
       ...MOCK_SUPPLIERS.filter(mockSup => !userAddedSuppliers.find(userSup => userSup.id === mockSup.id)),
       ...userAddedSuppliers

--- a/workspace/src/utils/productDetailUtils.ts
+++ b/workspace/src/utils/productDetailUtils.ts
@@ -174,7 +174,13 @@ export async function fetchProductDetails(productId: string): Promise<SimpleProd
 
   const storedProductsString = typeof window !== 'undefined' ? localStorage.getItem(USER_PRODUCTS_LOCAL_STORAGE_KEY) : null;
   if (storedProductsString) {
-    const userProducts: StoredUserProduct[] = JSON.parse(storedProductsString);
+    let userProducts: StoredUserProduct[] = [];
+    try {
+      userProducts = JSON.parse(storedProductsString);
+    } catch (err) {
+      console.error('Failed to parse user products from localStorage', err);
+      localStorage.removeItem(USER_PRODUCTS_LOCAL_STORAGE_KEY);
+    }
     const userProductData = userProducts.find(p => p.id === productId);
     if (userProductData) {
       let parsedCustomAttributes: CustomAttribute[] = [];


### PR DESCRIPTION
## Summary
- wrap JSON.parse calls in try/catch for product and supplier localStorage
- clear corrupted items and show toast warnings
- apply same logic across workspace copy

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684edd502d88832aaf0c196d1de6f658