### PR TITLE
centralize USER_PRODUCTS_LOCAL_STORAGE_KEY

### DIFF
--- a/src/app/(app)/products/new/page.tsx
+++ b/src/app/(app)/products/new/page.tsx
@@ -14,6 +14,7 @@ import type { ProductSupplyChainLink, SimpleLifecycleEvent, ProductComplianceSum
 import { fileToDataUri } from '@/utils/fileUtils';
 import AiExtractionSection from "@/components/products/new/AiExtractionSection";
 import ProductDetailsSection from "@/components/products/new/ProductDetailsSection";
+import { USER_PRODUCTS_LOCAL_STORAGE_KEY } from '@/types/dpp';
 
 type AiOrigin = 'AI_EXTRACTED' | 'manual' | undefined;
 
@@ -89,7 +90,6 @@ export interface StoredUserProduct extends Omit<ProductFormData, 'batteryRegulat
   batteryRegulation?: Partial<BatteryRegulationDetails>; // For detailed battery data for editing
 }
 
-const USER_PRODUCTS_LOCAL_STORAGE_KEY = 'norruvaUserProducts';
 
 const defaultBatteryRegulationState: Partial<BatteryRegulationDetails> = {
   status: "not_applicable", batteryChemistry: "", batteryPassportId: "",

--- a/src/hooks/useDPPLiveData.ts
+++ b/src/hooks/useDPPLiveData.ts
@@ -9,8 +9,7 @@ import type { DigitalProductPassport, DashboardFiltersState, SortConfig, Sortabl
 import { MOCK_DPPS } from '@/data';
 import { getSortValue } from '@/utils/sortUtils';
 import { useToast } from '@/hooks/use-toast';
-
-const USER_PRODUCTS_LOCAL_STORAGE_KEY = 'norruvaUserProducts';
+import { USER_PRODUCTS_LOCAL_STORAGE_KEY } from '@/types/dpp';
 
 export function useDPPLiveData() {
   const router = useRouter();


### PR DESCRIPTION
## Summary
- export and reuse USER_PRODUCTS_LOCAL_STORAGE_KEY
- import constant in hook and new product page instead of redeclaring

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684edd5537e8832a9ad268c9c88e79c1