### PR TITLE
Load contract addresses from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,16 @@ If the job ID is unknown a 404 error is returned:
     npm run copy:openapi
     ```
 
+### Environment Variables
+
+Add the deployed contract addresses to your `.env` file so the frontend can connect to them:
+
+```bash
+NEXT_PUBLIC_DPP_TOKEN_ADDRESS=0xDeployedDppTokenProxy
+NEXT_PUBLIC_NORU_TOKEN_ADDRESS=0xDeployedNoruTokenProxy
+NEXT_PUBLIC_GOVERNOR_ADDRESS=0xDeployedGovernorContract
+```
+
 ### Running the Development Server
 
 1.  **Start the Genkit development server (for AI features):**

--- a/src/config/contractAddresses.ts
+++ b/src/config/contractAddresses.ts
@@ -2,6 +2,14 @@
 // In a real deployment, these values should ideally be loaded from
 // environment variables for security and flexibility.
 
-export const DPP_TOKEN_ADDRESS: string = "YOUR_DEPLOYED_DPP_TOKEN_PROXY_ADDRESS";
-export const NORU_TOKEN_ADDRESS: string = "YOUR_DEPLOYED_NORU_TOKEN_PROXY_ADDRESS";
-export const GOVERNOR_ADDRESS: string = "YOUR_DEPLOYED_GOVERNOR_CONTRACT_ADDRESS";
+export const DPP_TOKEN_ADDRESS: string =
+  process.env.NEXT_PUBLIC_DPP_TOKEN_ADDRESS ||
+  "YOUR_DEPLOYED_DPP_TOKEN_PROXY_ADDRESS";
+
+export const NORU_TOKEN_ADDRESS: string =
+  process.env.NEXT_PUBLIC_NORU_TOKEN_ADDRESS ||
+  "YOUR_DEPLOYED_NORU_TOKEN_PROXY_ADDRESS";
+
+export const GOVERNOR_ADDRESS: string =
+  process.env.NEXT_PUBLIC_GOVERNOR_ADDRESS ||
+  "YOUR_DEPLOYED_GOVERNOR_CONTRACT_ADDRESS";


### PR DESCRIPTION
## Summary
- read contract addresses from environment variables
- document contract address variables in the README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run typecheck` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ee94dd3d4832a9e5c1ad4c922fa3e