### PR TITLE
Fix imports in API routes

### DIFF
--- a/src/app/api/transferOwnership/route.ts
+++ b/src/app/api/transferOwnership/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { DPP_TOKEN_ADDRESS } from '/workspace/nextjs-dpp/src/config/contractAddresses'; // Use absolute path
+// Use a relative import for the contract address configuration
+import { DPP_TOKEN_ADDRESS } from '../../../config/contractAddresses';
 import { ethers } from 'ethers'; // Assuming ethers.js is used
 
 export async function POST(request: Request) {

--- a/src/app/api/updateStatus/route.ts
+++ b/src/app/api/updateStatus/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ethers } from 'ethers'; // Assuming ethers.js is used
-import { DPP_TOKEN_ADDRESS } from '/workspace/digital-product-passport/src/config/contractAddresses'; // Use absolute path
+// Use a relative import for the contract address configuration
+import { DPP_TOKEN_ADDRESS } from '../../../config/contractAddresses';
 import DPPToken from '/workspace/digital-product-passport/artifacts/contracts/DPPToken.sol/DPPToken.json'; // Assuming Hardhat compilation output
 
 export async function POST(request: Request) {


### PR DESCRIPTION
## Summary
- update `transferOwnership` and `updateStatus` API routes to use relative imports
- run TypeScript compilation check

## Testing
- `npx --no-install tsc --noEmit` *(fails: unterminated strings in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_684ee94d661c832ab075f7efe488f8d7